### PR TITLE
Adds name and getPtr to Meta

### DIFF
--- a/include/Member.h
+++ b/include/Member.h
@@ -55,7 +55,7 @@ public:
     Member& addNonConstGetter(nonconst_ref_getter_func_ptr_t<Class, T> nonConstRefGetterPtr);
 
     // get sets methods can be used to add support
-    // for getters/setters for members instead of 
+    // for getters/setters for members instead of
     // direct access to them
     const T& get(const Class& obj) const;
     T getCopy(const Class& obj) const;

--- a/include/Member.h
+++ b/include/Member.h
@@ -60,6 +60,7 @@ public:
     const T& get(const Class& obj) const;
     T getCopy(const Class& obj) const;
     T& getRef(Class& obj) const;
+    member_ptr_t<Class, T> getPtr() const { return ptr; }
 
     template <typename V,
         typename = std::enable_if_t<std::is_constructible<T, V>::value>>

--- a/include/Meta.h
+++ b/include/Meta.h
@@ -32,6 +32,8 @@ auto meta::registerMembers<YourClass>()
 #endif
 
 #include <type_traits>
+#include <tuple>
+#include <utility>
 #include <string>
 
 // type_list is array of types

--- a/include/Meta.h
+++ b/include/Meta.h
@@ -32,6 +32,7 @@ auto meta::registerMembers<YourClass>()
 #endif
 
 #include <type_traits>
+#include <string>
 
 // type_list is array of types
 template <typename... Args>
@@ -52,6 +53,14 @@ auto members(Args&&... args);
 // function used for registration of classes by user
 template <typename Class>
 inline auto registerMembers();
+
+// function used for registration of class name by user
+template <typename Class>
+constexpr auto registerName();
+
+// returns set name for class
+template <typename Class>
+constexpr auto getName();
 
 // returns std::tuple of Members
 template <typename Class>

--- a/include/Meta.inl
+++ b/include/Meta.inl
@@ -1,7 +1,7 @@
 #include <cassert>
 #include <tuple>
 
-#include "Member.h" 
+#include "Member.h"
 #include "template_helpers.h"
 #include "detail/MetaHolder.h"
 
@@ -20,6 +20,18 @@ template <typename Class>
 inline auto registerMembers()
 {
     return std::make_tuple();
+}
+
+template <typename Class>
+constexpr auto registerName()
+{
+    return "";
+}
+
+template <typename Class>
+constexpr auto getName()
+{
+    return detail::MetaHolder<Class, decltype(registerMembers<Class>())>::name();
 }
 
 template <typename Class>

--- a/include/Meta.inl
+++ b/include/Meta.inl
@@ -48,7 +48,7 @@ constexpr bool isRegistered()
 
 // Check if Class has non-default ctor registered
 template <typename Class>
-constexpr static bool ctorRegistered()
+constexpr bool ctorRegistered()
 {
     return !std::is_same<type_list<>, constructor_arguments<Class>>::value;
 }

--- a/include/detail/MetaHolder.h
+++ b/include/detail/MetaHolder.h
@@ -17,6 +17,10 @@ namespace detail
 template <typename T, typename TupleType>
 struct MetaHolder {
     static TupleType members;
+    static const char* name() 
+    {
+        return registerName<T>();
+    }
 };
 
 template <typename T, typename TupleType>


### PR DESCRIPTION
Gives way to name holders using registerName.

Adds name() function to MetaHolder which returns the registered name of the class.

Interface is a bit icky (have to call two functions), open to suggestions.