### PR TITLE
Fix for types with only one registered member

### DIFF
--- a/include/template_helpers.inl
+++ b/include/template_helpers.inl
@@ -19,12 +19,24 @@ decltype(auto) apply_impl(F&& f, Tuple&& t, std::index_sequence<I...>)
 }
 
 template <typename F, typename Tuple>
+decltype(auto) apply_impl(F&& f, Tuple&& t)
+{
+    return std::forward<F>(f)(std::get<0>(std::forward<Tuple>(t)));
+}
+
+template <typename F, typename Tuple, typename = std::enable_if_t<(std::tuple_size<std::decay_t<Tuple>>::value > 1)>>
 decltype(auto) apply(F&& f, Tuple&& t)
 {
     using Indices =
         std::make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
 
     return apply_impl(std::forward<F>(f), std::forward<Tuple>(t), Indices{});
+}
+
+template <typename F, typename Tuple, typename = std::enable_if_t<!(std::tuple_size<std::decay_t<Tuple>>::value > 1)>, typename = void>
+decltype(auto) apply(F&& f, Tuple&& t)
+{
+    return apply_impl(std::forward<F>(f), std::forward<Tuple>(t));
 }
 
 template <typename F, typename TupleT>


### PR DESCRIPTION
Previously it wasn't possible to use `meta::doForAllMembers` on types with only one registered member (at least on MSVC15) because the `std::index_sequence` for the apply methods wasn't created properly from the size of the tuple of members.

Fix for [this issue](https://github.com/EliasD/MetaStuff/issues/3).